### PR TITLE
Add OpenAI data chunking utility and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Writeapp OpenAI Data API
+
+This project includes a small Python utility and web API for turning an OpenAI data export into an HTTP service. The intent is to host the API on platforms such as Railway.
+
+## Chunking OpenAI Data
+
+The `chunk_openai_data.py` script processes the `conversations.json` file from an OpenAI user data download. The conversations are split into smaller chunks for easier consumption by a chatbot or other clients.
+
+```
+python3 chunk_openai_data.py /path/to/conversations.json --output chunks.json --size 2000
+```
+
+`--size` controls the approximate maximum number of characters per chunk.
+
+## Running the API
+
+The provided `app.py` uses Flask. It loads the generated `chunks.json` file and exposes two endpoints:
+
+- `/chunks` returns the entire list of chunks.
+- `/chunk/<index>` returns a specific chunk by index.
+
+Use environment variable `DATA_FILE` to point to a custom chunk file and `PORT` to select the port (useful for Railway).
+
+```
+export DATA_FILE=chunks.json
+export PORT=8000
+python3 app.py
+```
+
+The API will be available at `http://localhost:8000/`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,26 @@
+import json
+import os
+from flask import Flask, jsonify, abort
+
+app = Flask(__name__)
+DATA_FILE = os.environ.get("DATA_FILE", "chunks.json")
+
+if os.path.exists(DATA_FILE):
+    with open(DATA_FILE) as f:
+        CHUNKS = json.load(f)
+else:
+    CHUNKS = []
+
+@app.route("/chunks")
+def get_chunks():
+    return jsonify(CHUNKS)
+
+@app.route("/chunk/<int:index>")
+def get_chunk(index: int):
+    if 0 <= index < len(CHUNKS):
+        return jsonify(CHUNKS[index])
+    return abort(404)
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 8000))
+    app.run(host="0.0.0.0", port=port)

--- a/chunk_openai_data.py
+++ b/chunk_openai_data.py
@@ -1,0 +1,44 @@
+import json
+import argparse
+from pathlib import Path
+
+
+def chunk_messages(messages, chunk_size=2000):
+    chunks = []
+    current = []
+    length = 0
+    for msg in messages:
+        text = msg.get('content') or msg.get('text') or ''
+        if length + len(text) > chunk_size and current:
+            chunks.append({"messages": current})
+            current = []
+            length = 0
+        current.append(msg)
+        length += len(text)
+    if current:
+        chunks.append({"messages": current})
+    return chunks
+
+
+def chunk_file(input_path: Path, output_path: Path, size: int):
+    with input_path.open() as f:
+        data = json.load(f)
+    conversations = data.get('conversations', data)
+    if not isinstance(conversations, list):
+        raise ValueError("Unsupported data format")
+    all_chunks = []
+    for conv in conversations:
+        messages = conv.get('messages', [])
+        all_chunks.extend(chunk_messages(messages, size))
+    with output_path.open('w') as f:
+        json.dump(all_chunks, f, indent=2)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Chunk OpenAI conversation data.')
+    parser.add_argument('input', help='Path to conversations.json from OpenAI export')
+    parser.add_argument('--output', default='chunks.json', help='Where to save chunked data')
+    parser.add_argument('--size', type=int, default=2000, help='Approx max characters per chunk')
+    args = parser.parse_args()
+
+    chunk_file(Path(args.input), Path(args.output), args.size)


### PR DESCRIPTION
## Summary
- add Python script to chunk OpenAI user export
- provide a simple Flask API to expose the chunks
- document usage in README

## Testing
- `python3 -m py_compile chunk_openai_data.py app.py`
- `python3 chunk_openai_data.py --help`
- `python3 app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6886d8358a2883268f29ab85335633c3