### PR TITLE
Fix duplicate metadata properties in layout.tsx

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,8 +4,6 @@ import './globals.css'
 export const metadata: Metadata = {
   title: 'WriteApp',
   description: 'A writing and blogging application',
-  title: 'Butterfiles - Writing Portfolio',
-  description: 'A portfolio of my writing',
 }
 
 export default function RootLayout({


### PR DESCRIPTION
Remove duplicate title and description properties that were causing TypeScript build errors.